### PR TITLE
Mark as read and unread as well as its indicators

### DIFF
--- a/src/main/java/gui/MailboxPage.form
+++ b/src/main/java/gui/MailboxPage.form
@@ -275,6 +275,9 @@
                 <Property name="text" type="java.lang.String" value="Mark Unread"/>
                 <Property name="enabled" type="boolean" value="false"/>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="b_markUnreadActionPerformed"/>
+              </Events>
             </Component>
           </SubComponents>
         </Container>
@@ -375,7 +378,7 @@
                     </Property>
                   </Properties>
                   <AuxValues>
-                    <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new javax.swing.JTable() {&#xa;    @Override&#xa;    public TableCellRenderer getCellRenderer(int row, int column) {&#xa;        // Get the email corresponding to the current row&#xa;        Emailable email = currentEmailType.get(row);&#xa;        // Update the current email of the renderer&#xa;        renderer.setCurrentEmail(email);&#xa;        // Return the renderer&#xa;        return renderer;&#xa;    }&#xa;}"/>
+                    <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new javax.swing.JTable() {&#xa;    @Override&#xa;    public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {&#xa;        Component c = super.prepareRenderer(renderer, row, column);&#xa;        if (!isRowSelected(row)) {&#xa;            c.setBackground(((Email) currentEmailType.get(row)).getRead() ? UColors.LIGHT_GREEN.toColor() : UColors.LIGHT_ORANGE.toColor());&#xa;        }&#xa;        return c;&#xa;    }&#xa;&#xa;    @Override&#xa;    public TableCellRenderer getCellRenderer(int row, int column) {&#xa;        // Get the email corresponding to the current row&#xa;        Emailable email = currentEmailType.get(row);&#xa;        // Update the current email of the renderer&#xa;        renderer.setCurrentEmail(email);&#xa;        // Return the renderer&#xa;        return renderer;&#xa;    }&#xa;}"/>
                     <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="inboxTable.getSelectionModel().addListSelectionListener(new ListSelectionListener(){&#xa;            public void valueChanged(ListSelectionEvent event) {&#xa;                retrieveMail();&#xa;            }&#xa;        });"/>
                   </AuxValues>
                 </Component>

--- a/src/main/java/gui/MailboxPage.java
+++ b/src/main/java/gui/MailboxPage.java
@@ -2,6 +2,7 @@ package gui;
 
 import models.interfaces.Emailable;
 import models.objects.Advertisement;
+import models.objects.Email;
 import models.objects.Session;
 import models.views.MailviewPanel;
 import models.views.inboxtable.CellsActionable;
@@ -9,6 +10,7 @@ import models.views.inboxtable.MailButton;
 import models.views.inboxtable.TableActionCellEditor;
 import models.views.inboxtable.TableActionCellRender;
 import utils.DatabaseUtils;
+import utils.UColors;
 
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
@@ -96,6 +98,15 @@ public class MailboxPage extends javax.swing.JFrame {
         INBOX_PANEL = new javax.swing.JPanel();
         jScrollPane1 = new javax.swing.JScrollPane();
         inboxTable = new javax.swing.JTable() {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                Component c = super.prepareRenderer(renderer, row, column);
+                if (!isRowSelected(row)) {
+                    c.setBackground(((Email) currentEmailType.get(row)).getRead() ? UColors.LIGHT_GREEN.toColor() : UColors.LIGHT_ORANGE.toColor());
+                }
+                return c;
+            }
+
             @Override
             public TableCellRenderer getCellRenderer(int row, int column) {
                 // Get the email corresponding to the current row
@@ -191,6 +202,11 @@ public class MailboxPage extends javax.swing.JFrame {
         b_markUnread.setFont(new java.awt.Font("Segoe UI", 1, 16)); // NOI18N
         b_markUnread.setText("Mark Unread");
         b_markUnread.setEnabled(false);
+        b_markUnread.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                b_markUnreadActionPerformed(evt);
+            }
+        });
 
         javax.swing.GroupLayout MAIL_TOOLSLayout = new javax.swing.GroupLayout(MAIL_TOOLS);
         MAIL_TOOLS.setLayout(MAIL_TOOLSLayout);
@@ -384,6 +400,7 @@ public class MailboxPage extends javax.swing.JFrame {
     }//GEN-LAST:event_b_findMailActionPerformed
 
     private void b_refreshActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_b_refreshActionPerformed
+        disableMailTools();
         emails = DatabaseUtils.getMailbox(session.getAccountUuid());
         i_inboxType.setSelectedIndex(0);
         cardSwitcher.show(MAIL_VIEW, "emptyview");
@@ -425,6 +442,19 @@ public class MailboxPage extends javax.swing.JFrame {
         currentEmailIndex = -1;
         updateTable(currentEmailType);
     }//GEN-LAST:event_i_inboxTypeActionPerformed
+
+    /**
+     * Method that runs whenever the {@link #b_markUnread} button is clicked. This method will set the current email and
+     * initiate necessary changes to the button.
+     * */
+    private void b_markUnreadActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_b_markUnreadActionPerformed
+        if (currentEmailIndex > -1) {
+            var email = (Email) currentEmailType.get(currentEmailIndex);
+            boolean isRead = b_markUnread.isSelected();
+            email.setRead(isRead);
+            markUnreadInit(email);
+        }
+    }//GEN-LAST:event_b_markUnreadActionPerformed
 
     /**
      * Disables the mail tools.
@@ -481,26 +511,23 @@ public class MailboxPage extends javax.swing.JFrame {
     private void retrieveMail() {
         this.currentEmailIndex = inboxTable.getSelectedRow();
         if (this.currentEmailIndex > -1) {
-            mailviewPanel.setCurrentEmail(currentEmailType.get(currentEmailIndex));
+            var email = (Email) currentEmailType.get(currentEmailIndex);
+            mailviewPanel.setCurrentEmail(email);
+            email.setRead(true);
             cardSwitcher.show(MAIL_VIEW, "mailview");
             enableMailTools();
+            markUnreadInit(email);
         }
     }
 
-    // /**
-    //  * @param args the command line arguments
-    //  */
-    // public static void main(String[] args) {
-    //     /* Set the Nimbus look and feel */
-    //     USwingAppearance.setLooksAndFeel();
-
-    //     /* Create and display the form */
-    //     java.awt.EventQueue.invokeLater(new Runnable() {
-    //         public void run() {
-    //             new MailboxPage().setVisible(true);
-    //         }
-    //     });
-    // }
+    /**
+     * Sets the mailbox tool's mark unread button to the current email's read status. This will also change the
+     * button label to "Mark Unread" if the email is read and "Mark Read" if the email is unread.
+     * */
+    private void markUnreadInit(Emailable email) {
+        b_markUnread.setSelected(email.getRead());
+        b_markUnread.setText(email.getRead() ? "Mark Unread" : "Mark Read");
+    }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel INBOX_PANEL;

--- a/src/main/java/gui/MailboxPage.java
+++ b/src/main/java/gui/MailboxPage.java
@@ -513,7 +513,18 @@ public class MailboxPage extends javax.swing.JFrame {
         if (this.currentEmailIndex > -1) {
             var email = (Email) currentEmailType.get(currentEmailIndex);
             mailviewPanel.setCurrentEmail(email);
+
+            // Set the mailview panel as sent or received
+            if (email.getSenderUuid().equals(session.getAccountUuid())) {
+                mailviewPanel.setAsSent();
+            } else {
+                mailviewPanel.setAsReceived();
+            }
+
+            // Set the mail as read / opened
             email.setRead(true);
+
+            // Switches the card layout to the mailview panel
             cardSwitcher.show(MAIL_VIEW, "mailview");
             enableMailTools();
             markUnreadInit(email);

--- a/src/main/java/models/views/MailviewPanel.java
+++ b/src/main/java/models/views/MailviewPanel.java
@@ -302,6 +302,14 @@ public class MailviewPanel extends javax.swing.JPanel {
         }
     }
 
+    public void setAsSent() {
+        this.l_from.setText("To");
+    }
+
+    public void setAsReceived() {
+        this.l_from.setText("From");
+    }
+
     // Getter email
 
     public Emailable getEmail() {

--- a/src/main/java/models/views/MailviewPanel.java
+++ b/src/main/java/models/views/MailviewPanel.java
@@ -11,8 +11,6 @@ import models.objects.Session;
 import utils.DatabaseUtils;
 
 import java.awt.*;
-import java.time.LocalTime;
-import java.util.Date;
 import java.util.Objects;
 import javax.swing.ImageIcon;
 

--- a/src/main/java/models/views/inboxtable/TableActionCellRender.java
+++ b/src/main/java/models/views/inboxtable/TableActionCellRender.java
@@ -1,7 +1,6 @@
 package models.views.inboxtable;
 
 import models.interfaces.Emailable;
-import models.objects.Email;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -15,7 +14,9 @@ import java.awt.*;
  * */
 
 public class TableActionCellRender extends DefaultTableCellRenderer {
-
+    /**
+     * Associated email
+     * */
     private Emailable currentEmail;
 
     public TableActionCellRender() {
@@ -26,7 +27,11 @@ public class TableActionCellRender extends DefaultTableCellRenderer {
     public void setCurrentEmail(Emailable currentEmail) {
         this.currentEmail = currentEmail;
     }
-    
+
+    /**
+     * This method sets the background color of the action buttons in the table so that it matches the table's
+     * background color.
+     * */
     @Override
     public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
         Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
@@ -40,6 +45,4 @@ public class TableActionCellRender extends DefaultTableCellRenderer {
         }
         return action;
     }
-    
-    
 }

--- a/src/main/java/utils/UColors.java
+++ b/src/main/java/utils/UColors.java
@@ -13,7 +13,9 @@ public enum UColors {
 	MAROON(0x952323),
 	RED(0xA73121),
 	BEIGE(0xDAD4B5),
-	IVORY(0xF2E8C6);
+	IVORY(0xF2E8C6),
+	LIGHT_GREEN(0x52fa58),
+	LIGHT_ORANGE(0xfaac46);
 
 	private final int colorHex;
 


### PR DESCRIPTION
![image](https://github.com/vianneynara/Konsmail/assets/98963440/5074bc1b-eb90-496c-bdca-aa9481e86a48)

Now every time an email is opened, it will set (locally, not updated to the database yet) to true and change its corresponding row indicator.